### PR TITLE
Implement stricter validation of --params and --hyper-params

### DIFF
--- a/deep_learning/dl_manager/classifiers/bert.py
+++ b/deep_learning/dl_manager/classifiers/bert.py
@@ -2,7 +2,7 @@ import tensorflow as tf
 import tensorflow_hub as hub
 import tensorflow_text as text
 
-from .model import AbstractModel, HyperParameter, InputEncoding
+from .model import AbstractModel, HyperParameter, InputEncoding, _fix_hyper_params
 
 
 class Bert(AbstractModel):
@@ -35,5 +35,6 @@ class Bert(AbstractModel):
         return False
 
     @classmethod
+    @_fix_hyper_params
     def get_hyper_parameters(cls) -> dict[str, HyperParameter]:
         return {} | super().get_hyper_parameters()

--- a/deep_learning/dl_manager/classifiers/fully_connected_model.py
+++ b/deep_learning/dl_manager/classifiers/fully_connected_model.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
 
-from .model import AbstractModel, HyperParameter, InputEncoding
+from .model import AbstractModel, HyperParameter, InputEncoding, _fix_hyper_params
 
 
 class FullyConnectedModel(AbstractModel):
@@ -39,6 +39,7 @@ class FullyConnectedModel(AbstractModel):
         return False
 
     @classmethod
+    @_fix_hyper_params
     def get_hyper_parameters(cls) -> dict[str, HyperParameter]:
         return {
             'number_of_hidden_layers': HyperParameter(default=1,

--- a/deep_learning/dl_manager/classifiers/linear_cnn_model.py
+++ b/deep_learning/dl_manager/classifiers/linear_cnn_model.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
 
-from .model import AbstractModel, HyperParameter, InputEncoding
+from .model import AbstractModel, HyperParameter, InputEncoding, _fix_hyper_params
 
 
 class LinearConv1Model(AbstractModel):
@@ -56,6 +56,7 @@ class LinearConv1Model(AbstractModel):
         return True
 
     @classmethod
+    @_fix_hyper_params
     def get_hyper_parameters(cls) -> dict[str, HyperParameter]:
         return {
             'fully_connected_layer_size': HyperParameter(

--- a/deep_learning/dl_manager/classifiers/linear_rnn_model.py
+++ b/deep_learning/dl_manager/classifiers/linear_rnn_model.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
 
-from .model import AbstractModel, HyperParameter, InputEncoding
+from .model import AbstractModel, HyperParameter, InputEncoding, _fix_hyper_params
 
 
 class LinearRNNModel(AbstractModel):
@@ -39,6 +39,7 @@ class LinearRNNModel(AbstractModel):
         return False
 
     @classmethod
+    @_fix_hyper_params
     def get_hyper_parameters(cls) -> dict[str, HyperParameter]:
         return {
             'bidirectional_layer_size': HyperParameter(

--- a/deep_learning/dl_manager/classifiers/model.py
+++ b/deep_learning/dl_manager/classifiers/model.py
@@ -41,6 +41,17 @@ class HyperParameter(typing.NamedTuple):
     default: numbers.Number
 
 
+def _fix_hyper_params(function):
+    def wrapper(*args):
+        hyper_params = function(*args)
+        assert isinstance(hyper_params, dict)
+        return {
+            name.replace('_', '-'): value
+            for name, value in hyper_params.items()
+        }
+    return wrapper
+
+
 ##############################################################################
 ##############################################################################
 # Main class

--- a/deep_learning/dl_manager/classifiers/nonlinear_cnn_model.py
+++ b/deep_learning/dl_manager/classifiers/nonlinear_cnn_model.py
@@ -2,7 +2,7 @@ from abc import ABC
 
 import tensorflow as tf
 
-from .model import AbstractModel, HyperParameter, InputEncoding
+from .model import AbstractModel, HyperParameter, InputEncoding, _fix_hyper_params
 
 
 class NonlinearConv2Model(AbstractModel):
@@ -59,6 +59,7 @@ class NonlinearConv2Model(AbstractModel):
         return True
 
     @classmethod
+    @_fix_hyper_params
     def get_hyper_parameters(cls) -> dict[str, HyperParameter]:
         return {
             'number_of_convolutions': HyperParameter(

--- a/deep_learning/dl_manager/cli.json
+++ b/deep_learning/dl_manager/cli.json
@@ -61,7 +61,8 @@
           "help": "Generator to use. Use `list` for options.",
           "style": "named",
           "nargs": "+",
-          "type": "str"
+          "type": "str",
+          "required": true
         },
         {
           "name": "output-mode",
@@ -69,7 +70,8 @@
           "help": "Output mode to use. Use `list` for options.",
           "style": "named",
           "nargs": "1",
-          "type": "str"
+          "type": "str",
+          "required": true
         },
         {
           "name": "file",
@@ -78,6 +80,7 @@
           "style": "named",
           "nargs": "1",
           "type": "class",
+          "required": true,
           "options": [
             "pathlib.Path"
           ]
@@ -125,7 +128,8 @@
           "help": "Amount of training epochs",
           "style": "named",
           "nargs": "1",
-          "type": "int"
+          "type": "int",
+          "required": true
         },
         {
           "name": "split-size",

--- a/deep_learning/dl_manager/config.py
+++ b/deep_learning/dl_manager/config.py
@@ -390,6 +390,8 @@ def _add_argument(parser,
         kwargs |= extra_args
     if argument.get('nargs', '1') != '1':
         kwargs['nargs'] = argument['nargs']
+    if argument.get('required', False):
+        kwargs['required'] = argument['required']
     if 'default' in argument:
         default_value = arg_type(argument['default'])
         if argument.get('nargs', '1') != '1':

--- a/deep_learning/dl_manager/feature_generators/bow.py
+++ b/deep_learning/dl_manager/feature_generators/bow.py
@@ -40,4 +40,4 @@ class AbstractBOW(AbstractFeatureGenerator, abc.ABC):
 
     @staticmethod
     def get_parameters() -> dict[str, ParameterSpec]:
-        return {} | super().get_parameters()
+        return {} | super(AbstractBOW, AbstractBOW).get_parameters()

--- a/deep_learning/dl_manager/feature_generators/doc2vec.py
+++ b/deep_learning/dl_manager/feature_generators/doc2vec.py
@@ -41,4 +41,4 @@ class Doc2Vec(AbstractFeatureGenerator):
             'vector-length': ParameterSpec(
                 description='specify the length of the output vector'
             ),
-        } | super().get_parameters()
+        } | super(Doc2Vec, Doc2Vec).get_parameters()

--- a/deep_learning/dl_manager/feature_generators/metadata.py
+++ b/deep_learning/dl_manager/feature_generators/metadata.py
@@ -16,4 +16,4 @@ class Metadata(AbstractFeatureGenerator):
 
     @staticmethod
     def get_parameters() -> dict[str, ParameterSpec]:
-        return {} | super().get_parameters()
+        return {} | super(Metadata, Metadata).get_parameters()

--- a/deep_learning/dl_manager/feature_generators/ontology_features.py
+++ b/deep_learning/dl_manager/feature_generators/ontology_features.py
@@ -69,4 +69,4 @@ class OntologyFeatures(AbstractFeatureGenerator):
 
     @staticmethod
     def get_parameters() -> dict[str, ParameterSpec]:
-        return super().get_parameters()
+        return super(OntologyFeatures, OntologyFeatures).get_parameters()

--- a/deep_learning/dl_manager/feature_generators/tfidf.py
+++ b/deep_learning/dl_manager/feature_generators/tfidf.py
@@ -47,4 +47,4 @@ class TfidfGenerator(AbstractFeatureGenerator):
 
     @staticmethod
     def get_parameters() -> dict[str, ParameterSpec]:
-        return super().get_parameters()
+        return super(TfidfGenerator, TfidfGenerator).get_parameters()

--- a/deep_learning/dl_manager/feature_generators/word2vec.py
+++ b/deep_learning/dl_manager/feature_generators/word2vec.py
@@ -45,4 +45,4 @@ class AbstractWord2Vec(AbstractFeatureGenerator, abc.ABC):
             'pretrained-binary': ParameterSpec(
                 description='specify is pretrained word2vec is binary'
             ),
-        } | super().get_parameters()
+        } | super(AbstractWord2Vec, AbstractWord2Vec).get_parameters()


### PR DESCRIPTION
This PR implements stricter checks of the inputs given for `--params` and `--hyper-params`. All passed  values must now actually be present in `FeatureGenerator.get_parameters()` or `ModelGenerator.get_hyper_parameters()`. 

The handling of underscores and dashed in these parameter names have also been normalized. Even if the user enters underscores, these will be converted to dashes. Also, `hyper-params` command now outputs dashes in stead of underscores.